### PR TITLE
Update Deluge SSL to v1.2

### DIFF
--- a/libs/synchronousdeluge/transfer.py
+++ b/libs/synchronousdeluge/transfer.py
@@ -19,7 +19,8 @@ class DelugeTransfer(object):
             self.disconnect()
 
         self.sock = socket.create_connection(hostport)
-        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLSv1)
+        #this is the spot to change, can we just put it to 1.2?
+        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLSv1.2) #the fuck is this?????
         self.connected = True
 
     def disconnect(self):


### PR DESCRIPTION
the latest version of deluge v2, no longer supports the use of tls v1.

### Description of what this fixes:
allow coughpotato to connect to new deluge v2 deamon

### Related issues:
...
