### PR TITLE
Deluge sslpatch 1

### DIFF
--- a/libs/synchronousdeluge/transfer.py
+++ b/libs/synchronousdeluge/transfer.py
@@ -19,7 +19,8 @@ class DelugeTransfer(object):
             self.disconnect()
 
         self.sock = socket.create_connection(hostport)
-        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLSv1)
+        #this is the spot to change, can we just put it to 1.2?
+        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLSv1.2) #the fuck is this?????
         self.connected = True
 
     def disconnect(self):

--- a/libs/synchronousdeluge/transfer.py
+++ b/libs/synchronousdeluge/transfer.py
@@ -19,8 +19,9 @@ class DelugeTransfer(object):
             self.disconnect()
 
         self.sock = socket.create_connection(hostport)
-        #this is the spot to change, can we just put it to 1.2?
-        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLSv1.2) #the fuck is this?????
+        #https://docs.python.org/2/library/ssl.html
+        #do we need to specify the tls version at all?
+        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLS)
         self.connected = True
 
     def disconnect(self):

--- a/libs/synchronousdeluge/transfer.py
+++ b/libs/synchronousdeluge/transfer.py
@@ -19,9 +19,10 @@ class DelugeTransfer(object):
             self.disconnect()
 
         self.sock = socket.create_connection(hostport)
-        #https://docs.python.org/2/library/ssl.html
-        #do we need to specify the tls version at all?
-        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLS)
+        try:
+            self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLSv1)
+        except AttributeError:
+            self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLS)
         self.connected = True
 
     def disconnect(self):


### PR DESCRIPTION
### Description of what this fixes:
Allow Deluge SSL to fallback to negotiation. 

### Related issues:
New Deluged v2 daemon does not support TLSv1
